### PR TITLE
Fix semantic-release problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@io-monad/novelous-extension",
   "description": "An extension that helps publishing your novel on various Japanese novel sites.",
   "author": "IRIDE Monad <iride.monad@gmail.com>",
+  "version": "0.0.0-placeholder",
   "license": "MIT",
   "homepage": "https://github.com/io-monad/novelous-extension",
   "repository": {

--- a/wercker.yml
+++ b/wercker.yml
@@ -36,7 +36,7 @@ build:
           echo "npm version $(npm -v) running"
 
 deploy:
-  steps:
+  after-steps:
     - script:
         name: semantic-release
         code: npm run semantic-release


### PR DESCRIPTION
Fix a few problems for semantic-release:

- npm warns for "No version in package.json", so we need a placeholder for version.
- Wercker alerts deploy task failure if semantic-release made no release because there are no changes to be released. To avoid this, we use `after-steps` instead of `steps` so that errors are ignored.